### PR TITLE
Added variable for Lambda description

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "reporter_lambda" {
   policy_json        = var.create_role ? data.aws_iam_policy_document.combined[0].json : null
 
   function_name = var.name
-  description   = "Send reports to the Kosli app"
+  description   = var.lambda_description
   handler       = "function.handler"
   runtime       = "provided.al2"
   # local_existing_package = data.null_data_source.downloaded_package.outputs["filename"]

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,9 @@ variable "lambda_timeout" {
   default     = 60
   description = "The amount of time Reporter Lambda Function has to run in seconds."
 }
+
+variable "lambda_description" {
+  type        = string
+  default     = "Send reports to the Kosli app"
+  description = "Lambda function description."
+}


### PR DESCRIPTION
## Description:
Sometimes we need to have more detailed, specific descriptions for Lambda functions, as there are many other Lambda functions in an AWS account.
This change only adds the possibility to modify the Lambda function description.

## Changes:
Added a Terraform variable called `lambda_description` with the original default value.