### PR TITLE
Add support for passing IAM Role Permission Boundary to downstream Lambda module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,12 +12,13 @@ module "reporter_lambda" {
   # local_existing_package = data.null_data_source.downloaded_package.outputs["filename"]
   local_existing_package = terraform_data.download_package.output
 
-  role_name      = var.create_role ? var.name : null
-  timeout        = var.lambda_timeout
-  create_package = false
-  publish        = true
-  create_role    = var.create_role
-  lambda_role    = var.create_role ? "" : var.role_arn
+  role_name                 = var.create_role ? var.name : null
+  role_permissions_boundary = var.role_permissions_boundary
+  timeout                   = var.lambda_timeout
+  create_package            = false
+  publish                   = true
+  create_role               = var.create_role
+  lambda_role               = var.create_role ? "" : var.role_arn
 
   environment_variables = {
     KOSLI_COMMAND   = local.kosli_command

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,12 @@ variable "role_arn" {
   default     = ""
 }
 
+variable "role_permissions_boundary" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function"
+  type        = string
+  default     = null
+}
+
 variable "kosli_api_token_ssm_parameter_name" {
   description = "The name of the kosli_api_token SSM parameter name"
   type        = string


### PR DESCRIPTION
Downstream `terraform-aws-modules/lambda/aws` module have support for iam role permission boundary.

This change simply passes it through if set to support organizations that require roles to have a permission boundary attached.