### PR TITLE
Removed deprecated IAM Policy for S3

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -46,7 +46,6 @@ data "aws_iam_policy_document" "s3_read_allow" {
     sid    = "S3Read"
     effect = "Allow"
     actions = [
-      "s3:ListObjects",
       "s3:ListBucket",
       "S3:GetObject"
     ]


### PR DESCRIPTION
Hi!
It appears that the IAM policy permission listed below no longer exists:
`s3:ListObjects`

![image](https://github.com/user-attachments/assets/22917fa2-0dd0-409b-9540-e738bd19fc6b)

The S3 Lambda reporter works fine after removing the policy.