### PR TITLE
Added IAM role and permission path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,8 @@ module "reporter_lambda" {
 
   role_name                 = var.create_role ? var.name : null
   role_permissions_boundary = var.role_permissions_boundary
+  role_path                 = var.role_path
+  policy_path               = var.policy_path
   timeout                   = var.lambda_timeout
   create_package            = false
   publish                   = true

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,18 @@ variable "role_permissions_boundary" {
   default     = null
 }
 
+variable "role_path" {
+  description = "Path of IAM role to use for Lambda Function"
+  type        = string
+  default     = null
+}
+
+variable "policy_path" {
+  description = "Path of policies to that should be added to IAM role for Lambda Function"
+  type        = string
+  default     = null
+}
+
 variable "kosli_api_token_ssm_parameter_name" {
   description = "The name of the kosli_api_token SSM parameter name"
   type        = string


### PR DESCRIPTION
Hi!
Feature request to support organization who has permissions boundary limited on specific IAM role and permissions **path**.
Added two new variables according to the main Terraform module (https://github.com/terraform-aws-modules/terraform-aws-lambda).

```
role_path
role_path
```