### PR TITLE
ci: auto-bump bundled Kosli CLI version via scheduled workflow

### DIFF
--- a/.github/workflows/check-cli-version.yml
+++ b/.github/workflows/check-cli-version.yml
@@ -1,0 +1,80 @@
+name: check-cli-version
+
+# Keeps the bundled Kosli CLI version current without manual maintenance.
+# On a schedule, this checks the latest kosli-dev/cli release and, when it is
+# newer than the kosli_cli_version default in variables.tf, opens a PR bumping
+# it. Consumers then pick it up via a normal module-version bump (Dependabot
+# terraform ecosystem).
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-cli-version:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Determine current and latest CLI versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Current default bundled in the module (the value consumers inherit).
+          CURRENT="$(grep -A4 'variable "kosli_cli_version"' variables.tf \
+            | grep -E '^[[:space:]]*default[[:space:]]*=' \
+            | sed -E 's/.*"(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+
+          # Latest published CLI release.
+          LATEST="$(gh api repos/kosli-dev/cli/releases/latest -q .tag_name)"
+
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+
+          echo "Current default: $CURRENT"
+          echo "Latest release:  $LATEST"
+
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "Already on the latest version; nothing to do."
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump kosli_cli_version default
+        if: steps.versions.outputs.bump == 'true'
+        env:
+          LATEST: ${{ steps.versions.outputs.latest }}
+        run: |
+          set -euo pipefail
+          # Only touch the `default = "vX.Y.Z"` line so the description example
+          # (which also mentions a version) is left untouched.
+          sed -i -E "/^[[:space:]]*default[[:space:]]*=/ s/\"v[0-9]+\.[0-9]+\.[0-9]+\"/\"${LATEST}\"/" variables.tf
+          echo "Updated variables.tf:"
+          grep -A4 'variable "kosli_cli_version"' variables.tf
+
+      - name: Open pull request
+        if: steps.versions.outputs.bump == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          commit-message: "chore(deps): bump Kosli CLI to ${{ steps.versions.outputs.latest }}"
+          title: "chore(deps): bump Kosli CLI to ${{ steps.versions.outputs.latest }}"
+          body: |
+            Automated bump of the bundled Kosli CLI version.
+
+            - Current: `${{ steps.versions.outputs.current }}`
+            - Latest:  `${{ steps.versions.outputs.latest }}`
+
+            Release notes: https://github.com/kosli-dev/cli/releases/tag/${{ steps.versions.outputs.latest }}
+          branch: auto/bump-cli-version
+          base: master
+          labels: dependencies
+          delete-branch: true

--- a/.github/workflows/check-cli-version.yml
+++ b/.github/workflows/check-cli-version.yml
@@ -19,7 +19,7 @@ jobs:
   check-cli-version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Determine current and latest CLI versions
         id: versions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         role-to-assume: arn:aws:iam::${{ secrets.KOSLI_REPORTER_SOURCES_AWS_ACCOUNT_ID }}:role/${{ github.event.repository.name }}
         aws-region: ${{ secrets.KOSLI_REPORTER_SOURCES_AWS_REGION }}
@@ -41,7 +41,7 @@ jobs:
     needs: [upload-package]
     steps:
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.KOSLI_REPORTER_REPO_ACCESS_TOKEN }}
           repository: kosli-dev/kosli-reporter


### PR DESCRIPTION
## What

Adds a scheduled GitHub Actions workflow (`.github/workflows/check-cli-version.yml`) that keeps the bundled Kosli CLI version current without manual maintenance.

Weekly (Monday 06:00 UTC) and on-demand via `workflow_dispatch`, it:
1. Reads the current `kosli_cli_version` default from `variables.tf`
2. Looks up the latest `kosli-dev/cli` release
3. If newer, opens a PR bumping the `default` line (e.g. the same change as commit `0c49a5c`)

## Why

The CLI version baked into the module is maintained by hand and drifts out of date (currently `v2.11.17` vs latest `v2.28.0`), producing stale-binary security findings for consumers. Dependabot can't track the CLI version directly the way it's pinned, so this fills that gap. Consumers then pick up the newer CLI via a normal module-version bump (Dependabot `terraform` ecosystem).

## Also in this PR

Pins all GitHub Actions across both workflows to commit SHAs with version comments for supply-chain safety. These remain Dependabot-updatable via the `github-actions` ecosystem.

## Notes

- The bump targets only the `default` line; the `description` format example is left static.